### PR TITLE
Fix version typo in CVE-2024-35184

### DIFF
--- a/2024/35xxx/CVE-2024-35184.json
+++ b/2024/35xxx/CVE-2024-35184.json
@@ -127,7 +127,7 @@
             "versions": [
               {
                 "status": "affected",
-                "version": "2.50",
+                "version": "2.5.0",
                 "lessThan": "2.8.6",
                 "versionType": "custom"
               }


### PR DESCRIPTION
I noticed the MITRE data had:

```json
      "affected": [
        {
          "vendor": "paperless-ngx",
          "product": "paperless-ngx",
          "versions": [
            {
              "status": "affected",
              "version": ">= 2.5.0, < 2.8.6"
            }
          ]
        }
      ],
```

But the CISA enrichment had:

```sh
            "versions": [
              {
                "status": "affected",
                "version": "2.50",
                "lessThan": "2.8.6",
                "versionType": "custom"
              }
            ],
```

Which looks to me to be a typo of `2.5.0` -> `2.50`. Simple enough to fix.