### PR TITLE
Removed Architecture from CVE-2024-5245 Version

### DIFF
--- a/2024/5xxx/CVE-2024-5245.json
+++ b/2024/5xxx/CVE-2024-5245.json
@@ -119,7 +119,7 @@
             "versions": [
               {
                 "status": "affected",
-                "version": "1.7.0.34 x64"
+                "version": "1.7.0.34"
               }
             ],
             "defaultStatus": "unknown"


### PR DESCRIPTION
Looking at CVE-2024-5245, I saw the CISA ADP had, what I thought to be, a questionable version string.

```json
        "affected": [
          {
            "cpes": [
              "cpe:2.3:a:netgear:prosafe_network_management_system:1.7.0.34:*:*:*:*:*:*:*"
            ],
            "vendor": "netgear",
            "product": "prosafe_network_management_system",
            "versions": [
              {
                "status": "affected",
                "version": "1.7.0.34 x64"
              }
            ],
            "defaultStatus": "unknown"
          }
        ],
```

Likely `x64` should not be in the version string. If we look at the vendor [advisory](https://kb.netgear.com/000066164/Security-Advisory-for-Multiple-Vulnerabilities-on-the-NMS300-PSV-2024-0003-PSV-2024-0004) they only list `1.7.0.34`. The reporting CNA, [ZDI](https://www.zerodayinitiative.com/advisories/ZDI-24-496/), makes no mention of a specific architecture in their advisory (nor version - thanks ZDI), but considering the vulnerability appears to be default creds, I assume architecture doesn't really come into play.

The product does come in Win32 and Win64 [variants](https://www.netgear.com/support/product/nms300/#download), but I think if we believed only the Win64 version to be vulnerable that would be reflected in the CPE and not the version string.