### PR TITLE
CVE-2023-5002 Assigned to Wrong Vendor/Product

### DIFF
--- a/2023/5xxx/CVE-2023-5002.json
+++ b/2023/5xxx/CVE-2023-5002.json
@@ -141,14 +141,14 @@
         "affected": [
           {
             "cpes": [
-              "cpe:2.3:a:linux:linux_kernel:-:*:*:*:*:*:*:*"
+              "cpe:2.3:a:pgadmin:pgadmin:*:*:*:*:*:*:*:*"
             ],
-            "vendor": "linux",
-            "product": "linux_kernel",
+            "vendor": "pgadmin",
+            "product": "pgadmin",
             "versions": [
               {
                 "status": "affected",
-                "version": "7.6*",
+                "version": "0",
                 "lessThan": "7.7",
                 "versionType": "custom"
               }


### PR DESCRIPTION
CVE-2023-5002 is a vulnerability affecting [pgAdmin](https://github.com/pgadmin-org/pgadmin4/issues/6763). Currently, CISA ADP indicates the vulnerability is associated with the Linux kernel.

Additionally, according to Red Hat's [bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2239164) and the pgAdmin [issue](https://github.com/pgadmin-org/pgadmin4/issues/6763), this was fixed in 7.7 and all previous versions are affected.

I'd also point out that `"version": "7.6*"` doesn't make a whole lot of sense in the first place. 