### PR TITLE
CVE-2023-25399 Incorrect Version Entry

### DIFF
--- a/2023/25xxx/CVE-2023-25399.json
+++ b/2023/25xxx/CVE-2023-25399.json
@@ -99,16 +99,16 @@
         "affected": [
           {
             "cpes": [
-              "cpe:2.3:a:scipy:scipy:-:*:*:*:*:*:*:*"
+              "cpe:2.3:a:scipy:scipy:*:*:*:*:*:*:*:*"
             ],
             "vendor": "scipy",
             "product": "scipy",
             "versions": [
               {
                 "status": "affected",
-                "version": "1.10.0*",
+                "version": "0",
                 "lessThan": "1.10.0",
-                "versionType": "custom"
+                "versionType": "semver"
               }
             ],
             "defaultStatus": "unknown"


### PR DESCRIPTION
CVE-2023-25399 [reportedly](https://web.archive.org/web/20230706040445/http://www.square16.org/achievement/cve-2023-25399/) affects SciPy before 1.10.0. The `versions` array didn't properly express this. Using `"lessThan":"1.10.0"` (which CISA already had) with `"version":"0"`, I believe, is the preferred way to describe the affected versions. 

Using `"version":"1.10.0*"` is not the appropriate way to express this, and I don't think it even describes a meaningful version range. I also mentioned this form of `version*` in https://github.com/cisagov/vulnrichment/pull/19 so this might be a wider problem that needs an issue created.