### PR TITLE
CVE-2023-28330 Incorrect Product and Versions

### DIFF
--- a/2023/28xxx/CVE-2023-28330.json
+++ b/2023/28xxx/CVE-2023-28330.json
@@ -160,59 +160,67 @@
         "affected": [
           {
             "cpes": [
-              "cpe:2.3:a:linux:linux_kernel:-:*:*:*:*:*:*:*"
+              "cpe:2.3:a:moodle:moodle:*:*:*:*:*:*:*:*"
             ],
-            "vendor": "linux",
-            "product": "linux_kernel",
+            "vendor": "moodle",
+            "product": "moodle",
             "versions": [
               {
                 "status": "affected",
-                "version": "4.1.0"
+                "version": "4.1.0",
+                "lessThan": "4.1.2",
+                "versionType": "semver"
               }
             ],
-            "defaultStatus": "unknown"
+            "defaultStatus": "unaffected"
           },
           {
             "cpes": [
-              "cpe:2.3:o:linux:linux_kernel:-:*:*:*:*:*:*:*"
+              "cpe:2.3:a:moodle:moodle:*:*:*:*:*:*:*:*"
             ],
-            "vendor": "linux",
-            "product": "linux_kernel",
+            "vendor": "moodle",
+            "product": "moodle",
             "versions": [
               {
                 "status": "affected",
-                "version": "4.0.0"
+                "version": "4.0.0",
+                "lessThan": "4.0.7",
+                "versionType": "semver"
               }
             ],
-            "defaultStatus": "unknown"
+            "defaultStatus": "unaffected"
           },
           {
             "cpes": [
-              "cpe:2.3:a:linux:linux_kernel:-:*:*:*:*:*:*:*"
+              "cpe:2.3:a:moodle:moodle:*:*:*:*:*:*:*:*"
             ],
-            "vendor": "linux",
-            "product": "linux_kernel",
+            "vendor": "moodle",
+            "product": "moodle",
             "versions": [
               {
                 "status": "affected",
-                "version": "3.11.0"
+                "version": "3.11.0",
+                "lessThan": "3.11.13",
+                "versionType": "semver"
               }
             ],
-            "defaultStatus": "unknown"
+            "defaultStatus": "unaffected"
           },
           {
             "cpes": [
-              "cpe:2.3:a:linux:linux_kernel:-:*:*:*:*:*:*:*"
+              "cpe:2.3:a:moodle:moodle:*:*:*:*:*:*:*:*"
             ],
-            "vendor": "linux",
-            "product": "linux_kernel",
+            "vendor": "moodle",
+            "product": "moodle",
             "versions": [
               {
                 "status": "affected",
-                "version": "0"
+                "version": "0",
+                "lessThan": "3.9.20",
+                "versionType": "semver"
               }
             ],
-            "defaultStatus": "unknown"
+            "defaultStatus": "unaffected"
           }
         ],
         "providerMetadata": {


### PR DESCRIPTION
CVE-2023-28330 is another vulnerability that the CISA ADP attributes to Linux/Linux Kernel, when it should in fact be [Moodle](https://moodle.org/mod/forum/discuss.php?d=445062). Additionally, the `versions` arrays are wrong. The CNA provided, as far as I can tell, a perfect versions array that describes all four vulnerable ranges. This got mistranslated in the CISA ADP, and somehow lost the `lessThan` portion... which was particularly bad on the last one since that just had `"version":"0"`.

I also think this is a good example of https://github.com/cisagov/vulnrichment/issues/4 - the CNA actually provided a very good and concise versions array, the CISA ADP (while still a usable format) creates a much bigger set of arrays.

