### PR TITLE
CVE-2023-6892 Incorrect CPE, Vendor, Product, and Version

### DIFF
--- a/2023/6xxx/CVE-2023-6892.json
+++ b/2023/6xxx/CVE-2023-6892.json
@@ -115,17 +115,19 @@
         "affected": [
           {
             "cpes": [
-              "cpe:2.3:a:woocommerce:woocommerce:*:*:*:*:*:wordpress:*:*"
+              "cpe:2.3:a:wpfactory:ean_for_woocommerce:*:*:*:*:*:wordpress:*:*"
             ],
-            "vendor": "woocommerce",
-            "product": "woocommerce",
+            "vendor": "wpfactory",
+            "product": "ean_for_woocommerce",
             "versions": [
               {
+                "version": "0",
                 "status": "affected",
-                "version": "*"
+                "lessThanOrEqual": "4.9.2",
+                "versionType": "semver"
               }
             ],
-            "defaultStatus": "unknown"
+            "defaultStatus": "unaffected"
           }
         ],
         "providerMetadata": {


### PR DESCRIPTION
The CISA ADP has the wrong CPE/vendor/product for CVE-2023-6892. The vendor and product should be wpfactory and ean_for_woocommerce respectively. This is a different product from woocommerce:

1. https://wordpress.org/plugins/ean-for-woocommerce/#description
2. https://wordpress.org/plugins/woocommerce/

EAN for WooCommerce also has an existing CPE (see https://nvd.nist.gov/vuln/detail/CVE-2023-0062) so I swapped that in. Finally, the versions array said "*" or  all versions are affected despite the CNA providing a reasonable version array. I've swapped in the CNA array.