### PR TITLE
Update CVE-2023-43526.json to reflect the chipset vulnerability as hardware

### DIFF
--- a/2023/43xxx/CVE-2023-43526.json
+++ b/2023/43xxx/CVE-2023-43526.json
@@ -252,7 +252,7 @@
         "affected": [
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -266,7 +266,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -280,7 +280,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -294,7 +294,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -308,7 +308,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -322,7 +322,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -336,7 +336,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -350,7 +350,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -364,7 +364,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -378,7 +378,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -392,7 +392,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -406,7 +406,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -420,7 +420,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -434,7 +434,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -448,7 +448,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -462,7 +462,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -476,7 +476,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -490,7 +490,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -504,7 +504,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -518,7 +518,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -532,7 +532,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -546,7 +546,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -560,7 +560,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -574,7 +574,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -588,7 +588,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -602,7 +602,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -616,7 +616,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -630,7 +630,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -644,7 +644,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -658,7 +658,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -672,7 +672,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -686,7 +686,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -700,7 +700,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -714,7 +714,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -728,7 +728,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -742,7 +742,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -756,7 +756,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",
@@ -770,7 +770,7 @@
           },
           {
             "cpes": [
-              "cpe:2.3:a:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
+              "cpe:2.3:h:qualcomm:snapdragon:*:*:*:*:*:*:*:*"
             ],
             "vendor": "qualcomm",
             "product": "snapdragon",


### PR DESCRIPTION
It appears that several qualcomm chipset CVEs need to be recategorized to "h" - hardware from "a" - application.

I fixed this one for an example.