### PR TITLE
Inconsistency between adp.affected and cna.affected in CVE-2024-32761

### DIFF
--- a/2024/32xxx/CVE-2024-32761.json
+++ b/2024/32xxx/CVE-2024-32761.json
@@ -146,7 +146,7 @@
             "product": "big-ip",
             "versions": [
               {
-                "status": "affected",
+                "status": "unaffected",
                 "version": "17.1.0"
               }
             ],
@@ -160,7 +160,7 @@
             "product": "big-ip",
             "versions": [
               {
-                "status": "affected",
+                "status": "unaffected",
                 "version": "16.1.0"
               }
             ],
@@ -176,6 +176,7 @@
               {
                 "status": "affected",
                 "version": "15.1.0"
+                "lessThan": "15.1.10",
               }
             ],
             "defaultStatus": "unknown"


### PR DESCRIPTION
While reviewing the JSON files, I discovered an inconsistency between the adp.affected and cna.affected fields in the CVE-2024-32761 record. I have corrected this mistake to ensure data accuracy and consistency across the CVE record. Please review the changes.

https://my.f5.com/manage/s/article/K000139217