### PR TITLE
CISA ADP Version Using Integer Instead of String

### DIFF
--- a/2024/30xxx/CVE-2024-30382.json
+++ b/2024/30xxx/CVE-2024-30382.json
@@ -292,7 +292,7 @@
             "versions": [
               {
                 "status": "affected",
-                "version": 0,
+                "version": "0",
                 "lessThan": "21.2R3-S8-EVO",
                 "versionType": "custom"
               }


### PR DESCRIPTION
There are a number of CISA ADP entries that have:

```
"version": 0,
```

However, version is a string field and this treats it as an integer, which inevitably will mess with actually using the data. I fixed this one but there are others.