### PR TITLE
Fix Jackson Databind Lower Bound

### DIFF
--- a/2020/36xxx/CVE-2020-36181.json
+++ b/2020/36xxx/CVE-2020-36181.json
@@ -260,7 +260,7 @@
             "versions": [
               {
                 "status": "affected",
-                "version": "0",
+                "version": "2.0.0",
                 "lessThan": "2.9.10.8",
                 "versionType": "custom"
               }


### PR DESCRIPTION
The description for CVE-2020-36181 says:

> FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp.cpdsadapter.DriverAdapterCPDS.

But the CISA ADP has:

```json
            "vendor": "fasterxml",
            "product": "jackson-databind",
            "versions": [
              {
                "status": "affected",
                "version": "0",
                "lessThan": "2.9.10.8",
                "versionType": "custom"
              }
            ],
```

The lowerbound of 0 appears to be incorrect. It should be 2.0.0 according to the description. That is also closer to what NIST currently has for the CVE:

![2024-06-01_04-54](https://github.com/cisagov/vulnrichment/assets/113205286/7a6c0631-289c-4da9-b36b-6e64586e9d99)

I'm not certain where NIST came up with that extra version range, but I digress.

Anyway, I think there are about 10 other jackson-databind CVE that suffer from the same issue (CVE-2020-10672, CVE-2020-10673, CVE-2020-10968, CVE-2020-10969, etc.)
