### PR TITLE
Fix Laravel Version Range

### DIFF
--- a/2024/29xxx/CVE-2024-29291.json
+++ b/2024/29xxx/CVE-2024-29291.json
@@ -91,7 +91,9 @@
             "versions": [
               {
                 "status": "affected",
-                "version": "8"
+                "version": "8.0",
+                "lessThanOrEqual": "11.0",
+                "versionType": "custom"
               }
             ],
             "defaultStatus": "unknown"


### PR DESCRIPTION
The disclosure and description for [CVE-2024-29291](https://gist.github.com/whiteman007/43bd7fa1fa0e47554b33f0cf93066784) both say Laravel 8.* through 11.*. These are highly questionable version ranges if you ask me, and it appears the vendor has no stance on the issue (and the CVE might even be bound for disputed status), but CISA ADP simply says version 8 is affected. It's slightly less wrong to say 8 through 11 is affected (although still imperfect).