### PR TITLE
Wrong Product in CVE-2024-5296

### DIFF
--- a/2024/5xxx/CVE-2024-5296.json
+++ b/2024/5xxx/CVE-2024-5296.json
@@ -95,10 +95,10 @@
         "affected": [
           {
             "cpes": [
-              "cpe:2.3:a:d-link:d-link:2.0.1.28:*:*:*:*:*:*:*"
+              "cpe:2.3:a:d-link:d-view:2.0.1.28:*:*:*:*:*:*:*"
             ],
             "vendor": "d-link",
-            "product": "d-link",
+            "product": "d-view",
             "versions": [
               {
                 "status": "affected",


### PR DESCRIPTION
Pretty self-explanatory, the reported product is "D-View" but that got transposed into "D-Link".