### PR TITLE
fix: fill affected versions in CVE-2022-48684

### DIFF
--- a/2022/48xxx/CVE-2022-48684.json
+++ b/2022/48xxx/CVE-2022-48684.json
@@ -106,7 +106,9 @@
             "versions": [
               {
                 "status": "affected",
-                "version": "-"
+                "version": "0",
+                "versionType": "custom",
+                "lessThanOrEqual": "7.1.0"
               }
             ],
             "defaultStatus": "unknown"


### PR DESCRIPTION
I read https://servicedesk.logpoint.com/hc/en-us/articles/7201134201885-Template-injection-in-Search-Template and filled in the affected versions.