### PR TITLE
Fix TrendMicro Apex One Version

### DIFF
--- a/2024/37xxx/CVE-2024-37289.json
+++ b/2024/37xxx/CVE-2024-37289.json
@@ -31,14 +31,14 @@
         "affected": [
           {
             "cpes": [
-              "cpe:2.3:a:trendmicro:apex_one:2019:*:*:*:*:*:*:*"
+              "cpe:2.3:a:trendmicro:apex_one:*:*:*:*:*:*:*:*"
             ],
             "vendor": "trendmicro",
             "product": "apex_one",
             "versions": [
               {
                 "status": "affected",
-                "version": "2019",
+                "version": "14.0",
                 "lessThan": "14.0.0.12980",
                 "versionType": "semver"
               }


### PR DESCRIPTION
Vendor reports the affected range oddly, but they clearly intended the lower bound to be 14.0 since "2019" doesn't make any sense. 