### PR TITLE
fix: correct affected versions in CVE-2023-32159

### DIFF
--- a/2023/32xxx/CVE-2023-32159.json
+++ b/2023/32xxx/CVE-2023-32159.json
@@ -112,14 +112,16 @@
         "affected": [
           {
             "cpes": [
-              "cpe:2.3:a:pdf-xchange:pdf-xchange_editor:9.3.361.0:*:*:*:*:*:*:*"
+              "cpe:2.3:a:pdf-xchange:pdf-xchange_editor:*:*:*:*:*:*:*:*"
             ],
             "vendor": "pdf-xchange",
             "product": "pdf-xchange_editor",
             "versions": [
               {
                 "status": "affected",
-                "version": "9.3.361.0"
+                "version": "0",
+                "lessThan": "9.4.362.0",
+                "versionType": "custom"
               }
             ],
             "defaultStatus": "unknown"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

CVE-2023-32159 is linked to ZDI-23-641 and ZDI-CAN-17765.
According to the [pdf-xchange-editor history](https://www.tracker-software.com/product/pdf-xchange-editor/history), ZDI-CAN-17765 was fixed in `9.4.362.0`, and earlier versions are likely affected.(`9.3.361.0`, but also`9.3.360.0` and earlier versions may be affected.


## 📷 Screenshots (if appropriate) ##

![Screenshot from 2024-06-18 17-03-25](https://github.com/cisagov/vulnrichment/assets/16035056/3c80bb6b-b63e-433a-ad3d-f8c7d32cddd8)
