### PR TITLE
fix: correct affected versions in CVE-2024-1347

### DIFF
--- a/2024/1xxx/CVE-2024-1347.json
+++ b/2024/1xxx/CVE-2024-1347.json
@@ -157,16 +157,22 @@
             "product": "gitlab",
             "versions": [
               {
+                "version": "0",
                 "status": "affected",
-                "version": "0.0"
+                "lessThan": "16.9.6",
+                "versionType": "semver"
               },
               {
+                "version": "16.10.0",
                 "status": "affected",
-                "version": "16.10"
+                "lessThan": "16.10.4",
+                "versionType": "semver"
               },
               {
+                "version": "16.11.0",
                 "status": "affected",
-                "version": "16.11"
+                "lessThan": "16.11.1",
+                "versionType": "semver"
               }
             ],
             "defaultStatus": "unknown"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

The versions indicated by GitLab's Release and the version actually described in ADP Container are different.
ADP content is only `0.0` and `16.10`,`16.11`. Fix this so that the correct version is eligible.

> Domain based restrictions bypass using a crafted email address
>
>An issue has been discovered in GitLab CE/EE affecting all versions before 16.9.6, all versions starting from 16.10 before 16.10.4, all versions starting from 16.11 before 16.11.1. Under certain conditions, an attacker through a crafted email address may be able to bypass domain based restrictions on an instance or a group. This is a medium severity issue (CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N, 4.3). It is now mitigated in the latest release and is assigned [CVE-2024-1347](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-1347).

https://about.gitlab.com/releases/2024/04/24/patch-release-gitlab-16-11-1-released/