### PR TITLE
fix: correct affected versions in CVE-2024-4006

### DIFF
--- a/2024/4xxx/CVE-2024-4006.json
+++ b/2024/4xxx/CVE-2024-4006.json
@@ -141,56 +141,28 @@
         "affected": [
           {
             "cpes": [
-              "cpe:2.3:a:gitlab:gitlab:16.7.0:*:*:*:community:*:*:*"
+              "cpe:2.3:a:gitlab:gitlab:*:*:*:*:*:*:*:*"
             ],
             "vendor": "gitlab",
             "product": "gitlab",
             "versions": [
               {
+                "version": "16.7.0",
                 "status": "affected",
-                "version": "16.7.0"
-              }
-            ],
-            "defaultStatus": "unknown"
-          },
-          {
-            "cpes": [
-              "cpe:2.3:a:gitlab:gitlab:16.7.0:*:*:*:enterprise:*:*:*"
-            ],
-            "vendor": "gitlab",
-            "product": "gitlab",
-            "versions": [
+                "lessThan": "16.9.6",
+                "versionType": "semver"
+              },
               {
+                "version": "16.10.0",
                 "status": "affected",
-                "version": "16.7.0"
-              }
-            ],
-            "defaultStatus": "unknown"
-          },
-          {
-            "cpes": [
-              "cpe:2.3:a:gitlab:gitlab:16.10:*:*:*:*:*:*:*"
-            ],
-            "vendor": "gitlab",
-            "product": "gitlab",
-            "versions": [
+                "lessThan": "16.10.4",
+                "versionType": "semver"
+              },
               {
+                "version": "16.11.0",
                 "status": "affected",
-                "version": "16.10"
-              }
-            ],
-            "defaultStatus": "unknown"
-          },
-          {
-            "cpes": [
-              "cpe:2.3:a:gitlab:gitlab:16.11:*:*:*:*:*:*:*"
-            ],
-            "vendor": "gitlab",
-            "product": "gitlab",
-            "versions": [
-              {
-                "status": "affected",
-                "version": "16.11"
+                "lessThan": "16.11.1",
+                "versionType": "semver"
               }
             ],
             "defaultStatus": "unknown"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

The versions indicated by GitLab's Release and the version actually described in ADP Container are different.
ADP content is only `16.7.0` and `16.10`,`16.11`. Fix this so that the correct version is eligible.

> An issue has been discovered in GitLab CE/EE affecting all versions starting from 16.7 before 16.9.6, all versions starting from 16.10 before 16.10.4, all versions starting from 16.11 before 16.11.1 where personal access scopes were not honored by GraphQL subscriptions. This is a medium severity issue (CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N, 4.3). It is now mitigated in the latest release and is assigned [CVE-2024-4006](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-4006).

https://about.gitlab.com/releases/2024/04/24/patch-release-gitlab-16-11-1-released/