### PR TITLE
fix: correct affected versions of gitlab release:2024-04-24 

### DIFF
--- a/2024/2xxx/CVE-2024-2434.json
+++ b/2024/2xxx/CVE-2024-2434.json
@@ -150,42 +150,28 @@
         "affected": [
           {
             "cpes": [
-              "cpe:2.3:a:gitlab:gitlab:16.10.0:*:*:*:*:*:*:*"
+              "cpe:2.3:a:gitlab:gitlab:*:*:*:*:*:*:*:*"
             ],
             "vendor": "gitlab",
             "product": "gitlab",
             "versions": [
               {
+                "version": "16.9.0",
                 "status": "affected",
-                "version": "16.10.0"
-              }
-            ],
-            "defaultStatus": "unknown"
-          },
-          {
-            "cpes": [
-              "cpe:2.3:a:gitlab:gitlab:16.11.0:*:*:*:*:*:*:*"
-            ],
-            "vendor": "gitlab",
-            "product": "gitlab",
-            "versions": [
+                "lessThan": "16.9.6",
+                "versionType": "semver"
+              },
               {
+                "version": "16.10.0",
                 "status": "affected",
-                "version": "16.11.0"
-              }
-            ],
-            "defaultStatus": "unknown"
-          },
-          {
-            "cpes": [
-              "cpe:2.3:a:gitlab:gitlab:16.9.0:*:*:*:*:*:*:*"
-            ],
-            "vendor": "gitlab",
-            "product": "gitlab",
-            "versions": [
+                "lessThan": "16.10.4",
+                "versionType": "semver"
+              },
               {
+                "version": "16.11.0",
                 "status": "affected",
-                "version": "16.9.0"
+                "lessThan": "16.11.1",
+                "versionType": "semver"
               }
             ],
             "defaultStatus": "unknown"

--- a/2024/2xxx/CVE-2024-2829.json
+++ b/2024/2xxx/CVE-2024-2829.json
@@ -150,14 +150,28 @@
         "affected": [
           {
             "cpes": [
-              "cpe:2.3:a:gitlab:gitlab:-:*:*:*:-:*:*:*"
+              "cpe:2.3:a:gitlab:gitlab:*:*:*:*:-:*:*:*"
             ],
             "vendor": "gitlab",
             "product": "gitlab",
             "versions": [
               {
+                "version": "12.5.0",
                 "status": "affected",
-                "version": "-"
+                "lessThan": "16.9.6",
+                "versionType": "semver"
+              },
+              {
+                "version": "16.10.0",
+                "status": "affected",
+                "lessThan": "16.10.4",
+                "versionType": "semver"
+              },
+              {
+                "version": "16.11.0",
+                "status": "affected",
+                "lessThan": "16.11.1",
+                "versionType": "semver"
               }
             ],
             "defaultStatus": "unknown"

--- a/2024/4xxx/CVE-2024-4024.json
+++ b/2024/4xxx/CVE-2024-4024.json
@@ -142,42 +142,28 @@
         "affected": [
           {
             "cpes": [
-              "cpe:2.3:a:gitlab:gitlab:-:*:*:*:-:*:*:*"
+              "cpe:2.3:a:gitlab:gitlab:*:*:*:*:-:*:*:*"
             ],
             "vendor": "gitlab",
             "product": "gitlab",
             "versions": [
               {
+                "version": "7.8.0",
                 "status": "affected",
-                "version": "7.8"
-              }
-            ],
-            "defaultStatus": "unknown"
-          },
-          {
-            "cpes": [
-              "cpe:2.3:a:gitlab:gitlab:-:*:*:*:-:*:*:*"
-            ],
-            "vendor": "gitlab",
-            "product": "gitlab",
-            "versions": [
+                "lessThan": "16.9.6",
+                "versionType": "semver"
+              },
               {
+                "version": "16.10.0",
                 "status": "affected",
-                "version": "16.10"
-              }
-            ],
-            "defaultStatus": "unknown"
-          },
-          {
-            "cpes": [
-              "cpe:2.3:a:gitlab:gitlab:-:*:*:*:-:*:*:*"
-            ],
-            "vendor": "gitlab",
-            "product": "gitlab",
-            "versions": [
+                "lessThan": "16.10.4",
+                "versionType": "semver"
+              },
               {
+                "version": "16.11.0",
                 "status": "affected",
-                "version": "16.11"
+                "lessThan": "16.11.1",
+                "versionType": "semver"
               }
             ],
             "defaultStatus": "unknown"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Revised all other CVEs referenced in [GitLab Release](https://about.gitlab.com/releases/2024/04/24/patch-release-gitlab-16-11-1-released/) referring to #70, #71, and modified the version affected by the ADP contentainer part.
