### PR TITLE
fix: correct affected versions of APSB24-26

### DIFF
--- a/2024/20xxx/CVE-2024-20794.json
+++ b/2024/20xxx/CVE-2024-20794.json
@@ -144,15 +144,15 @@
             "versions": [
               {
                 "status": "affected",
-                "version": "0",
-                "versionType": "custom",
-                "lessThanOrEqual": "24.0.1 "
+                "version": "23.0.0",
+                "versionType": "semver",
+                "lessThanOrEqual": "23.0.4"
               },
               {
                 "status": "affected",
-                "version": "0",
-                "versionType": "custom",
-                "lessThanOrEqual": "23.0.4"
+                "version": "24.0.0",
+                "versionType": "semver",
+                "lessThanOrEqual": "24.0.1"
               }
             ],
             "defaultStatus": "unknown"

--- a/2024/20xxx/CVE-2024-20795.json
+++ b/2024/20xxx/CVE-2024-20795.json
@@ -144,15 +144,15 @@
             "versions": [
               {
                 "status": "affected",
-                "version": "0",
-                "versionType": "custom",
-                "lessThanOrEqual": "24.0.1 "
+                "version": "23.0.0",
+                "versionType": "semver",
+                "lessThanOrEqual": "23.0.4"
               },
               {
                 "status": "affected",
-                "version": "0",
-                "versionType": "custom",
-                "lessThanOrEqual": "23.0.4"
+                "version": "24.0.0",
+                "versionType": "semver",
+                "lessThanOrEqual": "24.0.1"
               }
             ],
             "defaultStatus": "unknown"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

In the case of the current writing style, all versions below `24.0.1` are targeted, but as long as [the release](https://helpx.adobe.com/security/products/animate/apsb24-26.html) is read, I think that the version should be defined in the 2023 and 2024 series.
At least, it is a problem that the 23.x.y version, which is larger than `23.0.4`, will be affected.

