### PR TITLE
Update affected versions for CVE-2024-7969

### DIFF
--- a/2024/7xxx/CVE-2024-7969.json
+++ b/2024/7xxx/CVE-2024-7969.json
@@ -49,17 +49,17 @@
             "cpes": [
               "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*"
             ],
-            "vendor": "google",
-            "product": "chrome",
+            "vendor": "Google",
+            "product": "Chrome",
             "versions": [
               {
                 "status": "affected",
                 "version": "0",
-                "lessThan": "128.0.6613.84",
+                "lessThan": "128.0.6613.113",
                 "versionType": "custom"
               }
             ],
-            "defaultStatus": "unknown"
+            "defaultStatus": "unaffected"
           }
         ],
         "problemTypes": [


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

The change to the affected/unaffected versions here makes it more explicit that updated to 128.0.6613.113 or later mitigates this vulnerability. The prior version data simply marked past versions as affected and made no reference to the available fixed version.

## 💭 Motivation and context ##

Removes guessing as to which version is no longer vulnerable.