### PR TITLE
Update CVE-2024-11703.json

### DIFF
--- a/2024/11xxx/CVE-2024-11703.json
+++ b/2024/11xxx/CVE-2024-11703.json
@@ -9,15 +9,15 @@
             "cvssV3_1": {
               "scope": "UNCHANGED",
               "version": "3.1",
-              "baseScore": 9.1,
-              "attackVector": "NETWORK",
-              "baseSeverity": "CRITICAL",
-              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+              "baseScore": 5.7,
+              "attackVector": "PHYSICAL",
+              "baseSeverity": "MEDIUM",
+              "vectorString": "CVSS:3.1/AV:P/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:N",
               "integrityImpact": "HIGH",
-              "userInteraction": "NONE",
+              "userInteraction": "REQUIRED",
               "attackComplexity": "LOW",
               "availabilityImpact": "NONE",
-              "privilegesRequired": "NONE",
+              "privilegesRequired": "LOW",
               "confidentialityImpact": "HIGH"
             }
           },


### PR DESCRIPTION
- [x] This is a change to the CVSS rating as part of the vulnrichment by CISA. I am aware that the CVE is handled by Mozilla directly (which I work for).

A reporter of the bug has brought to our attention, that the CVSS values are likely not correct. (The bug was reported multiple times by various folks, because of the low complexity).

- The attack requires physical access to the device (changing `attackVector`)
- The attacker is required to be fully logged in to the device (we're assuming that people protect their personal devices with PIN, pattern or other means of authentication like face recognition)

Given my understanding of CVSS and some help from the CVSS calculator, I believe this may result in a score of 5.7 and a severity of "medium", not "critical". But I'm happy to discuss this further.