### PR TITLE
Update CVE-2024-52271 CISA ADP SSVC & CVSS

### DIFF
--- a/2024/52xxx/CVE-2024-52271.json
+++ b/2024/52xxx/CVE-2024-52271.json
@@ -5,21 +5,6 @@
       {
         "title": "CISA ADP Vulnrichment",
         "metrics": [
-          {
-            "cvssV3_1": {
-              "scope": "CHANGED",
-              "version": "3.1",
-              "baseScore": 7.9,
-              "attackVector": "LOCAL",
-              "baseSeverity": "HIGH",
-              "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:L/I:H/A:L",
-              "integrityImpact": "HIGH",
-              "userInteraction": "NONE",
-              "attackComplexity": "LOW",
-              "availabilityImpact": "LOW",
-              "privilegesRequired": "LOW",
-              "confidentialityImpact": "LOW"
-            }
           },
           {
             "other": {
@@ -29,10 +14,10 @@
                 "role": "CISA Coordinator",
                 "options": [
                   {
-                    "Exploitation": "poc"
+                    "Exploitation": "active"
                   },
                   {
-                    "Automatable": "no"
+                    "Automatable": "yes"
                   },
                   {
                     "Technical Impact": "partial"


### PR DESCRIPTION
1. CISA ADP SSVC data is incorrect, requesting update to the correct metrics.
2. CISA ADP CVSS is not missing from the CNA and as such should be removed per the [MITRE guidelines for CISA ADP](https://www.cve.org/ProgramOrganization/ADPs)