### PR TITLE
Update vulnrichment_big.dot for new flow

### DIFF
--- a/assets/vulnrichment_big.dot
+++ b/assets/vulnrichment_big.dot
@@ -19,11 +19,9 @@ digraph vulnrichment {
 	"automatable" [label="Automatable?" shape="diamond"]
 	"cwe" [label="CWE?" shape="diamond"]
 	"cvss" [label="CVSS?" shape="diamond"]
-	"cpe" [label="CPE?" shape="diamond"]
 	"references" [label="Additional\nreferences?" shape="diamond"]
 	"do_cwe" [label="Add CWE" shape="box"]
 	"do_cvss" [label="Add CVSS" shape="box"]
-	"do_cpe" [label="Add CPE" shape="box"]
 	"do_references" [label="Add\nreferences" shape="box"]
 	"github" [label="GitHub" shape="box"]
 	"adp" [label="ADP" shape="box"]
@@ -97,12 +95,7 @@ digraph vulnrichment {
 		cwe -> cvss [label=" yes"]
 		cwe -> do_cwe [label=" no"]
 		do_cwe -> cvss
-		cvss -> cpe [label=" yes"]
 		cvss -> do_cvss [label=" no"]
-		do_cvss -> cpe
-		cpe -> references [label=" yes"]
-		cpe -> do_cpe [label=" no"]
-		do_cpe -> references
 		references -> do_references [label=" yes"]
 		references -> enrich_stop [label=" no"]
 		do_references -> enrich_stop


### PR DESCRIPTION
This removes the CPE steps from the flowchart. See #148. 

I don't know the magic you use to generate the SVG, so I've not tested this. Also, we should document that somewhere so we can do this without blocking on @amanion-cisa's machine. :)
