### PR TITLE
Adjust scoring of CVE-2023-51219

### DIFF
--- a/2023/51xxx/CVE-2023-51219.json
+++ b/2023/51xxx/CVE-2023-51219.json
@@ -21,26 +21,34 @@
         "providerMetadata": {
           "orgId": "af854a3a-2127-422b-91ae-364da2661108",
           "shortName": "CVE",
-          "dateUpdated": "2024-08-02T22:32:09.181Z"
+          "dateUpdated": "2025-02-08T22:08:33.004Z"
         }
       },
       {
         "title": "CISA ADP Vulnrichment",
         "metrics": [
           {
+            "cvssV4_0": {
+              "version": "4.0",
+              "baseScore": 8.6,
+              "baseSeverity": "HIGH",
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:A/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+            }
+          },
+          {
             "cvssV3_1": {
               "scope": "UNCHANGED",
               "version": "3.1",
-              "baseScore": 6.5,
+              "baseScore": 8.8,
               "attackVector": "NETWORK",
-              "baseSeverity": "MEDIUM",
-              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L",
-              "integrityImpact": "NONE",
-              "userInteraction": "NONE",
+              "baseSeverity": "HIGH",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "integrityImpact": "HIGH",
+              "userInteraction": "REQUIRED",
               "attackComplexity": "LOW",
-              "availabilityImpact": "LOW",
+              "availabilityImpact": "HIGH",
               "privilegesRequired": "NONE",
-              "confidentialityImpact": "LOW"
+              "confidentialityImpact": "HIGH"
             }
           },
           {
@@ -51,13 +59,13 @@
                 "role": "CISA Coordinator",
                 "options": [
                   {
-                    "Exploitation": "none"
+                    "Exploitation": "active"
                   },
                   {
-                    "Automatable": "no"
+                    "Automatable": "yes"
                   },
                   {
-                    "Technical Impact": "partial"
+                    "Technical Impact": "total"
                   }
                 ],
                 "version": "2.0.3",
@@ -72,8 +80,8 @@
               {
                 "lang": "en",
                 "type": "CWE",
-                "cweId": "CWE-444",
-                "description": "CWE-444 Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')"
+                "cweId": "CWE-94",
+                "description": "CWE-94 Improper Control of Generation of Code ('Code Injection')"
               }
             ]
           }
@@ -81,19 +89,19 @@
         "providerMetadata": {
           "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
           "shortName": "CISA-ADP",
-          "dateUpdated": "2024-06-05T14:49:59.035Z"
+          "dateUpdated": "2025-02-08T22:08:33.004Z"
         }
       }
     ],
     "cna": {
       "affected": [
         {
-          "vendor": "n/a",
-          "product": "n/a",
+          "vendor": "kakaocorp",
+          "product": "kakaotalk",
           "versions": [
             {
               "status": "affected",
-              "version": "n/a"
+              "version": "10.4.3"
             }
           ]
         }
@@ -109,7 +117,7 @@
       "descriptions": [
         {
           "lang": "en",
-          "value": "A deep link validation issue in KakaoTalk 10.4.3 allowed a remote adversary to direct users to run any attacker-controlled JavaScript within a WebView. The impact was further escalated by triggering another WebView that leaked its access token in a HTTP request header. Ultimately, this access token could be used to take over another user's account and read her/his chat messages."
+          "value": "A deep link validation issue in KakaoTalk 10.4.3 allowed a remote adversary to direct users to run any attacker-controlled JavaScript within a vulnerable WebView that leaked its access token in a HTTP request header. Ultimately, this access token could be used to take over another user's account and read her/his chat messages."
         }
       ],
       "problemTypes": [
@@ -126,14 +134,14 @@
       "providerMetadata": {
         "orgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
         "shortName": "mitre",
-        "dateUpdated": "2024-06-25T19:48:35.920521"
+        "dateUpdated": "2025-02-08T22:08:33.004Z"
       }
     }
   },
   "cveMetadata": {
     "cveId": "CVE-2023-51219",
     "state": "PUBLISHED",
-    "dateUpdated": "2024-11-12T19:24:45.004Z",
+    "dateUpdated": "2025-02-08T22:08:33.004Z",
     "dateReserved": "2023-12-18T00:00:00",
     "assignerOrgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
     "datePublished": "2024-06-03T00:00:00",


### PR DESCRIPTION
Hi there,

I discovered `CVE-2023-51219` (see my [blog post](https://stulle123.github.io/posts/kakaotalk-account-takeover/)).

Here's my reasoning to update the score:

`"userInteraction": "REQUIRED"`

The user has to click a link in order to execute the attack.

`"confidentialityImpact": "HIGH"`

This was an account takeover, so an attacker could have access to all users' chat messages.

`"integrityImpact": "HIGH"`

An attacker could tamper with all existing messages (e.g., edit already sent messages).

`"availabilityImpact": "HIGH"`

An attacker could delete already sent messages.

If you require more explanations please do let me know.

Cheers,

stulle123