### PR TITLE
Update CVE-2025-31201.json

### DIFF
--- a/2025/31xxx/CVE-2025-31201.json
+++ b/2025/31xxx/CVE-2025-31201.json
@@ -122,8 +122,8 @@
           "versions": [
             {
               "status": "affected",
-              "version": "unspecified",
-              "lessThan": "15.4",
+              "version": "15.0",
+              "lessThan": "15.4.1",
               "versionType": "custom"
             }
           ]


### PR DESCRIPTION
My expectation with this PR is to correctly scope the applicability of this CVE via the CPE. If the formatting is correct, I will submit PRs to fix the same issue affecting other CVEs with a too broad CPE scope.

The current CPE marks CVE-2025-31201 as applicable to all macOS versions (1.0 < 15.4)

At least for macOS, CVE-2025-31201 is only applicable to Sequoia and not previous releases of macOS, thus macOS 15.0 < 15.4.1.

This is the original apple release addressing this vuln: https://support.apple.com/en-us/122400
This CVE is not mentioned in any other macos release notes.

I have sent a similar request to the CNA directly as well.


<!-- 
# Please note!

While we appreciate your efforts to make Vulnrichment better, please note the [README](https://github.com/cisagov/vulnrichment?tab=readme-ov-file#issues-and-pull-requests) guidance on PRs: If your PR is proposing changes to a CVE ADP record directly, it is unlikely to be merged in the usual way due to the way we build CISA-ADP container on the back end. We will definitely use your code as a guide, but you may not see an actual merge. We'll note this in this PR when your proposal makes it to production (or doesn't).

In a related vein, if your PR is an attempt to update a CVE record *outside* of the CISA-ADP container, it will almost certainly be rejected. No offense intended, but if you have an issue with a CVE record, the best place to deal with errors or omissions is the [CNA](https://www.cve.org/PartnerInformation/ListofPartners) or the [CVE Program](https://cveform.mitre.org) directly.

If your PR is anything other than an edit to a CVE record (such as documentation or examples), we're able to handle it as a typical pull request.

Finally, please make sure to describe what you intend to accomplish with your PR. That way we can assess it and make any suggestions to further your goals.

Thanks for your interest in Vulnrichment!
-->
