### PR TITLE
CVE-2025-4802: Correct CVSS vector and score

### DIFF
--- a/2025/4xxx/CVE-2025-4802.json
+++ b/2025/4xxx/CVE-2025-4802.json
@@ -25,15 +25,15 @@
             "cvssV3_1": {
               "scope": "UNCHANGED",
               "version": "3.1",
-              "baseScore": 9.8,
-              "attackVector": "NETWORK",
-              "baseSeverity": "CRITICAL",
-              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "baseScore": 7.8,
+              "attackVector": "LOCAL",
+              "baseSeverity": "HIGH",
+              "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
               "integrityImpact": "HIGH",
               "userInteraction": "NONE",
               "attackComplexity": "LOW",
               "availabilityImpact": "HIGH",
-              "privilegesRequired": "NONE",
+              "privilegesRequired": "LOW",
               "confidentialityImpact": "HIGH"
             }
           },
@@ -63,7 +63,7 @@
         "providerMetadata": {
           "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
           "shortName": "CISA-ADP",
-          "dateUpdated": "2025-05-17T02:32:36.641Z"
+          "dateUpdated": "2025-05-19T23:15:03.000Z"
         }
       }
     ],


### PR DESCRIPTION
The attack vector and privileges required for CVE-2025-4802 are the same as for CVE-2023-4911, so use the same CVSS vector and score.