### PR TITLE
Update Score of CVE-2025-24294

### DIFF
--- a/2025/24xxx/CVE-2025-24294.json
+++ b/2025/24xxx/CVE-2025-24294.json
@@ -9,14 +9,14 @@
             "cvssV3_1": {
               "scope": "UNCHANGED",
               "version": "3.1",
-              "baseScore": 5.3,
+              "baseScore": 7.5,
               "attackVector": "NETWORK",
-              "baseSeverity": "MEDIUM",
-              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "baseSeverity": "HIGH",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
               "integrityImpact": "NONE",
               "userInteraction": "NONE",
               "attackComplexity": "LOW",
-              "availabilityImpact": "LOW",
+              "availabilityImpact": "HIGH",
               "privilegesRequired": "NONE",
               "confidentialityImpact": "NONE"
             }


### PR DESCRIPTION
Hi, I'm finder of  `CVE-2025-24294` See ([dos-resolv-cve-2025-24294/](https://www.ruby-lang.org/en/news/2025/07/08/dos-resolv-cve-2025-24294/))

My reasoning for changes are:

` "availabilityImpact": "HIGH"`

resolv gem can cause `high cpu` usage resulting in application thread to become unresponsive specially for the case where server is not that powerful (as that was the result of my assessment). The GitHub Security Advisory for this CVE (https://github.com/advisories/GHSA-xh69-987w-hrp8) also supports this finding by using the cvss v4.0 framework. It lists the `Vulnerable System Impact Metrics` as `Availability: High` compared to `Availability: Low` metric in the current  cvss v3.1 score.
