### PR TITLE
Update CVE-2025-46121

### DIFF
--- a/2025/46xxx/CVE-2025-46121.json
+++ b/2025/46xxx/CVE-2025-46121.json
@@ -9,15 +9,15 @@
             "cvssV3_1": {
               "scope": "UNCHANGED",
               "version": "3.1",
-              "baseScore": 7.2,
+              "baseScore": 9.8,
               "attackVector": "NETWORK",
-              "baseSeverity": "HIGH",
-              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+              "baseSeverity": "CRITICAL",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
               "integrityImpact": "HIGH",
               "userInteraction": "NONE",
               "attackComplexity": "LOW",
               "availabilityImpact": "HIGH",
-              "privilegesRequired": "HIGH",
+              "privilegesRequired": "NONE",
               "confidentialityImpact": "HIGH"
             }
           },


### PR DESCRIPTION
For CVE-2025-46121 there are two ways to exploit the vulnerability. Both methods are described at the referenced URL (https://sector7.computest.nl/post/2025-07-ruckus-unleashed/).

The first method requires administrative authentication and utilizes the API the exploit the vulnerability, which would correctly reflect the current score. However, the second method utilizes DHCP and does not require any authentication. Therefore, the required permissions for this vulnerability should be set to none.

Please let me know if you have any questions.