### PR TITLE
Exploitation Active on CVE-2025-8875 and CVE-2025-8876

### DIFF
--- a/2025/8xxx/CVE-2025-8875.json
+++ b/2025/8xxx/CVE-2025-8875.json
@@ -128,7 +128,7 @@
                 "role": "CISA Coordinator",
                 "options": [
                   {
-                    "Exploitation": "none"
+                    "Exploitation": "active"
                   },
                   {
                     "Automatable": "no"


### PR DESCRIPTION
This vulnerability is listed in the KEV. It should be marked "exploitation: active."

See:

https://todb.github.io/kev-lite/#details-CVE-2025-8875
https://todb.github.io/kev-lite/#details-CVE-2025-8876

This also applies to CVE-2025-8876, but weirdly, I don't see the JSON for that in the repo at the moment.
