### PR TITLE
Fix CVSS v3.1 vector and severity for CVE-2025-56795

### DIFF
--- a/2025/56xxx/CVE-2025-56795.json
+++ b/2025/56xxx/CVE-2025-56795.json
@@ -7,18 +7,18 @@
         "metrics": [
           {
             "cvssV3_1": {
-              "scope": "CHANGED",
+              "scope": "UNCHANGED",
               "version": "3.1",
-              "baseScore": 6.1,
+              "baseScore": 8.0,
               "attackVector": "NETWORK",
-              "baseSeverity": "MEDIUM",
-              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
-              "integrityImpact": "LOW",
+              "baseSeverity": "HIGH",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H",
+              "integrityImpact": "HIGH",
               "userInteraction": "REQUIRED",
               "attackComplexity": "LOW",
-              "availabilityImpact": "NONE",
-              "privilegesRequired": "NONE",
-              "confidentialityImpact": "LOW"
+              "availabilityImpact": "HIGH",
+              "privilegesRequired": "LOW",
+              "confidentialityImpact": "HIGH"
             }
           },
           {


### PR DESCRIPTION
The vulnerability is a Stored XSS in Mealie <= 3.0.1. An attacker with low privileges can inject malicious JavaScript into recipe fields, which will execute when any user (including administrators) views the recipe. This allows for:
- Session hijacking
- Administrative account compromise (creation/deletion of accounts, data modification)
- Data theft and loss of integrity

Because the attack requires only recipe creation and minimal user interaction, with potential full compromise of confidentiality, integrity, and availability, the corrected CVSS score is 8.0 (High):

CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H 
