### PR TITLE
Update CVE-2025-56558.json

### DIFF
--- a/2025/56xxx/CVE-2025-56558.json
+++ b/2025/56xxx/CVE-2025-56558.json
@@ -9,15 +9,15 @@
             "cvssV3_1": {
               "scope": "UNCHANGED",
               "version": "3.1",
-              "baseScore": 7.5,
+              "baseScore": 2.0,
               "attackVector": "NETWORK",
-              "baseSeverity": "HIGH",
-              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-              "integrityImpact": "HIGH",
-              "userInteraction": "NONE",
-              "attackComplexity": "LOW",
+              "baseSeverity": "LOW",
+              "vectorString": "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:N",
+              "integrityImpact": "LOW",
+              "userInteraction": "REQUIRED",
+              "attackComplexity": "HIGH",
               "availabilityImpact": "NONE",
-              "privilegesRequired": "NONE",
+              "privilegesRequired": "HIGH",
               "confidentialityImpact": "NONE"
             }
           },
@@ -84,7 +84,7 @@
             "version": "3.1",
             "baseScore": 3,
             "baseSeverity": "LOW",
-            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:C/C:N/I:L/A:N"
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:N"
           }
         }
       ],
@@ -122,7 +122,7 @@
       "descriptions": [
         {
           "lang": "en",
-          "value": "The Dyson MQTT server (2022 and possibly later) allows publications and subscriptions by a client that has the correct values of AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, and device serial number, even if a device (such as a Pure Hot+Cool device) has been removed and is not visible in the supported MyDyson app. This could allow an unexpected actor to obtain control and set the room temperature (up to 37 Celsius) if ownership of the device is transferred without wiping the device. NOTE: the Supplier's position is that this is \"a potential vulnerability that dates back 4 years ago in 2022 and we are unable to replicate that anymore.\""
+          "value": "The Dyson MQTT server (2022 and possibly later) allows publications and subscriptions by a client that has the correct values of AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, and device serial number, even if a device (such as a Pure Hot+Cool device) has been removed and is not visible in the supported MyDyson app. This could allow an unexpected actor to obtain control and set the room temperature (up to 37 Celsius) if ownership of the device is transferred without wiping the device. NOTE: the Supplier's position is that this is \"a potential vulnerability that dates back 4 years ago in 2022 and we are unable to replicate that anymore. Based on the submitted report, in order to compromise this, an attacker needs to own the device with full privileges, sniff for the AWS credentials, and then transferring ownership to the victim. This requires 'user interaction' to prepare prior to the attack, with the attacker having full privileges to the target machine, and attempting to sniff for the AWS credentials and write a script for exploitation with high complexity, without the ability of stealing any information or create high impact for the victim other than the likes of changing temperatures. The scope for this is extremely small.\""
         }
       ],
       "problemTypes": [


### PR DESCRIPTION
This is the dyson cyber team. We've assessed this vulnerability with the product owners and determined that the CVSS base scores weren't reflective of the attack scenario. As we were not consulted for this CVE, we are now sending in our inputs to revise the scoring. We have communicated this with MITRE and MITRE has directed us to send in this PR.

<!-- 
# Please note!

While we appreciate your efforts to make Vulnrichment better, please note the [README](https://github.com/cisagov/vulnrichment?tab=readme-ov-file#issues-and-pull-requests) guidance on PRs: If your PR is proposing changes to a CVE ADP record directly, it is unlikely to be merged in the usual way due to the way we build CISA-ADP container on the back end. We will definitely use your code as a guide, but you may not see an actual merge. We'll note this in this PR when your proposal makes it to production (or doesn't).

In a related vein, if your PR is an attempt to update a CVE record *outside* of the CISA-ADP container, it will almost certainly be rejected. No offense intended, but if you have an issue with a CVE record, the best place to deal with errors or omissions is the [CNA](https://www.cve.org/PartnerInformation/ListofPartners) or the [CVE Program](https://cveform.mitre.org) directly.

If your PR is anything other than an edit to a CVE record (such as documentation or examples), we're able to handle it as a typical pull request.

Finally, please make sure to describe what you intend to accomplish with your PR. That way we can assess it and make any suggestions to further your goals.

Thanks for your interest in Vulnrichment!
-->
