### PR TITLE
CVE-2025-0647: Fix several CVSS v3.1 metrics

### DIFF
--- a/2025/0xxx/CVE-2025-0647.json
+++ b/2025/0xxx/CVE-2025-0647.json
@@ -7,18 +7,18 @@
         "metrics": [
           {
             "cvssV3_1": {
-              "scope": "UNCHANGED",
+              "scope": "CHANGED",
               "version": "3.1",
-              "baseScore": 5.4,
-              "attackVector": "NETWORK",
-              "baseSeverity": "MEDIUM",
-              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N",
-              "integrityImpact": "LOW",
+              "baseScore": 7.2,
+              "attackVector": "LOCAL",
+              "baseSeverity": "HIGH",
+              "vectorString": "CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:C/C:H/I:H/A:N",
+              "integrityImpact": "HIGH",
               "userInteraction": "NONE",
-              "attackComplexity": "LOW",
+              "attackComplexity": "HIGH",
               "availabilityImpact": "NONE",
-              "privilegesRequired": "LOW",
-              "confidentialityImpact": "LOW"
+              "privilegesRequired": "HIGH",
+              "confidentialityImpact": "HIGH"
             }
           },
           {


### PR DESCRIPTION
Hi Vulnrichment team,

I noticed CVE-2025-0647 was enriched and the CISA-ADP CVSS v3.1 vector is currently set to CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N.

My understanding is that this is not a network-driven issue. The practical scenario is a virtualized system where a privileged, untrusted guest OS executes CPP RCTX on a given core, and a TLBI directed at that same PE may not take effect. If the hypervisor proceeds assuming the flush worked, stale stage-2 translations can persist while pages are unmapped and later reallocated, which can let the guest access memory that is now owned by the host or another VM. See my modelled scenario here: https://graph.volerion.com/view?ID=CVE-2025-0647

With that framing, I think AV should be 'local', PR should be 'high', and the scope should be 'changed' (guest to host or cross-VM boundary). To reflect the operational preconditions (landing on the same PE, timing/ordering with TLBI, and page reuse), there is also a reasonable case for AC being 'high'.

Let me know if you agree with this scenario and the resulting CVSS metric changes.

Thanks!