### PR TITLE
CVE-2025-65397: Fix AV and AC CVSS 3.1 metrics

### DIFF
--- a/2025/65xxx/CVE-2025-65397.json
+++ b/2025/65xxx/CVE-2025-65397.json
@@ -11,7 +11,7 @@
               "version": "3.1",
               "baseScore": 6.4,
               "attackVector": "PHYSICAL",
-              "baseSeverity": "HIGH",
+              "baseSeverity": "MEDIUM",
               "vectorString": "CVSS:3.1/AV:P/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
               "integrityImpact": "HIGH",
               "userInteraction": "NONE",

--- a/2025/65xxx/CVE-2025-65397.json
+++ b/2025/65xxx/CVE-2025-65397.json
@@ -9,13 +9,13 @@
             "cvssV3_1": {
               "scope": "UNCHANGED",
               "version": "3.1",
-              "baseScore": 8.4,
-              "attackVector": "LOCAL",
+              "baseScore": 6.4,
+              "attackVector": "PHYSICAL",
               "baseSeverity": "HIGH",
-              "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "vectorString": "CVSS:3.1/AV:P/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
               "integrityImpact": "HIGH",
               "userInteraction": "NONE",
-              "attackComplexity": "LOW",
+              "attackComplexity": "HIGH",
               "availabilityImpact": "HIGH",
               "privilegesRequired": "NONE",
               "confidentialityImpact": "HIGH"


### PR DESCRIPTION
Hi Vulnrichment team,

I noticed CVE-2025-65397 was enriched and the CISA-ADP CVSS v3.1 vector is currently set to CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H.

My understanding is that this is not a purely local issue. The practical scenario is an attacker with physical access to a Blurams Flare Camera who can place a maliciously crafted auth.ini file on the device's SD card. If the device is missing /opt/images/public_key.der, the safe_exec.sh startup script's insecure authentication mechanism can be abused to execute arbitrary commands with root privileges. See my modelled scenario here: https://graph.volerion.com/view?ID=CVE-2025-65397

With that framing, I think AV should be 'physical', and to reflect the target-specific prerequisite (the missing public_key.der file), I think AC should be 'high'.

Let me know if you agree with this scenario and the resulting CVSS metric changes.

Thanks!

P.S. if you rather want me to create an issue, instead of a PR, due to the way your internal system is setup (with this repo being output), then let me know. An issue would be easier for me to create than a PR.