### PR TITLE
CVE-2025-67084: Fix PR, S, and CIA CVSS 3.1 metrics

### DIFF
--- a/2025/67xxx/CVE-2025-67084.json
+++ b/2025/67xxx/CVE-2025-67084.json
@@ -7,18 +7,18 @@
         "metrics": [
           {
             "cvssV3_1": {
-              "scope": "UNCHANGED",
+              "scope": "CHANGED",
               "version": "3.1",
-              "baseScore": 6.5,
+              "baseScore": 9.9,
               "attackVector": "NETWORK",
-              "baseSeverity": "MEDIUM",
-              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
-              "integrityImpact": "LOW",
+              "baseSeverity": "CRITICAL",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H",
+              "integrityImpact": "HIGH",
               "userInteraction": "NONE",
               "attackComplexity": "LOW",
-              "availabilityImpact": "NONE",
-              "privilegesRequired": "NONE",
-              "confidentialityImpact": "LOW"
+              "availabilityImpact": "HIGH",
+              "privilegesRequired": "LOW",
+              "confidentialityImpact": "HIGH"
             }
           },
           {


### PR DESCRIPTION
Hi Vulnrichment team,

I noticed CVE-2025-67084 was enriched and the CISA-ADP CVSS v3.1 vector is currently set to CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N.

My understanding is that this issue results in remote code execution in both the exposed web instance and on the underlying OS. The practical scenario is an attacker who can reach the web interface and, with at least 'low' privileges (description states authenticated), trigger the vulnerable behavior to achieve RCE. See my modelled scenario here: https://graph.volerion.com/view?ID=CVE-2025-67084

With that framing, I think PR should be 'low', the scope should be 'changed', and the impacts should be 'high' across confidentiality, integrity, and availability (resulting in CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H).

Let me know if you agree with this scenario and the resulting CVSS metric changes.

Thanks!