### PR TITLE
CVE-2025-63644: Fix PR CVSS 3.1 metric

### DIFF
--- a/2025/63xxx/CVE-2025-63644.json
+++ b/2025/63xxx/CVE-2025-63644.json
@@ -9,15 +9,15 @@
             "cvssV3_1": {
               "scope": "CHANGED",
               "version": "3.1",
-              "baseScore": 6.1,
+              "baseScore": 5.4,
               "attackVector": "NETWORK",
               "baseSeverity": "MEDIUM",
-              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
               "integrityImpact": "LOW",
               "userInteraction": "REQUIRED",
               "attackComplexity": "LOW",
               "availabilityImpact": "NONE",
-              "privilegesRequired": "NONE",
+              "privilegesRequired": "LOW",
               "confidentialityImpact": "LOW"
             }
           },


### PR DESCRIPTION
Hi Vulnrichment team,

I noticed CVE-2025-63644 was enriched and the CISA-ADP CVSS v3.1 vector is currently set to PR:N

My understanding is that this is a stored XSS in the user profile description field, where exploitation requires an authenticated actor who can modify a profile description (either a regular user modifying their own profile, or an admin modifying another user's profile). See my modelled scenario here: https://graph.volerion.com/view?ID=CVE-2025-63644

Based on that scenario, I think PR should be at least 'low' rather than 'none'. I think the rest of the metrics are set correctly. With PR adjusted, the resulting vector would be CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N.

Let me know if you agree with this scenario and the resulting CVSS metric changes.

Thanks!