### PR TITLE
Update CVSS v3.1 metrics for CVE-2025-67825, adjusting base score, at…

### DIFF
--- a/2025/67xxx/CVE-2025-67825.json
+++ b/2025/67xxx/CVE-2025-67825.json
@@ -9,16 +9,16 @@
             "cvssV3_1": {
               "scope": "UNCHANGED",
               "version": "3.1",
-              "baseScore": 9.8,
-              "attackVector": "NETWORK",
-              "baseSeverity": "CRITICAL",
-              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "baseScore": 5.5,
+              "attackVector": "LOCAL",
+              "baseSeverity": "MEDIUM",
+              "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
               "integrityImpact": "HIGH",
-              "userInteraction": "NONE",
+              "userInteraction": "REQUIRED",
               "attackComplexity": "LOW",
-              "availabilityImpact": "HIGH",
+              "availabilityImpact": "NONE",
               "privilegesRequired": "NONE",
-              "confidentialityImpact": "HIGH"
+              "confidentialityImpact": "NONE"
             }
           },
           {


### PR DESCRIPTION
Hi,

Regarding CVE-2025-67825, the current CVSS score assessment differs from our internal calculation.

The existing vector, CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H, designates the Attack Vector (AV) as Network. However, this should be Local (L), as the document must reside on the local system. Furthermore, since user interaction is required to open the file, the User Interaction (UI) value should be Required (R). We also believe Confidentiality (C) and Availability (A) should be set to None (N), as the issue does not impact these components.

Based on our assessment, the CVSS score should be 5.5 with the vector AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N.