### PR TITLE
CVE-2026-2100: add fixed version at 0.26.2 as per github release

### DIFF
--- a/2026/2xxx/CVE-2026-2100.json
+++ b/2026/2xxx/CVE-2026-2100.json
@@ -28,6 +28,25 @@
             }
           }
         ],
+        "cpeApplicability": [
+          {
+            "operator": "OR",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:p11-kit_project:p11-kit:*:*:*:*:*:*:*:*",
+                    "versionStartIncluding": "0",
+                    "versionEndExcluding": "0.26.2"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
         "providerMetadata": {
           "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
           "shortName": "CISA-ADP",


### PR DESCRIPTION
Upstream released version [0.26.2](https://github.com/p11-glue/p11-kit/releases/tag/0.26.2) which resolves this [CVE-2026-2100](https://nvd.nist.gov/vuln/detail/CVE-2026-2100). Add fixed range to ADP container.

This removes false finding of an unfixed CVE across millions of containers deployed and used by agencies that are requesting updates on this CVE due to scanners using NVD data that so far claims that there is no known fix for this CVE.

Request to update this entry was also sent to the CNA of last resort,
mitre and NVD. However, this route might be the quickest way to
resolve this.

In terms of US Office of Management and Budget, merging this update will save millions of hours for agency workers who have to spend time trianging this finding that appears on remediated versions of software.
