### PR TITLE
Adjust scoring of CVE-2026-14216

### DIFF
--- a/2026/14xxx/CVE-2026-14216.json
+++ b/2026/14xxx/CVE-2026-14216.json
@@ -9,7 +9,7 @@
             "cvssV3_1": {
               "scope": "UNCHANGED",
               "version": "3.1",
-              "baseScore": 5.3,
+              "baseScore": 6.5,
               "attackVector": "NETWORK",
               "baseSeverity": "MEDIUM",
               "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L",


### PR DESCRIPTION
Fixes #333.

The CISA ADP container on `CVE-2026-14216` carries `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L` with `baseScore: 5.3`. Working the 3.1 equations for that vector:

```
ISS          = 1 - ((1 - 0) * (1 - 0.22) * (1 - 0.22)) = 0.3916
Impact       = 6.42 * 0.3916                           = 2.514072
Exploitability = 8.22 * 0.85 * 0.77 * 0.85 * 0.85      = 3.887042775
Roundup(2.514072 + 3.887042775) = Roundup(6.401114775) = 6.5
```

5.3 is what the same vector scores with `A:N`, so the score looks like it was carried over from a version without the availability impact.

The decomposed fields already agree with the vector (`availabilityImpact: LOW`), so the smallest consistent change is the score, which this makes 6.5. `baseSeverity` stays `MEDIUM`, since 6.5 is inside the 4.0 to 6.9 band.

If the intent was `A:N` after all, then the vector and `availabilityImpact` need to change instead and this PR is the wrong half; happy to flip it.
